### PR TITLE
Update package version and add plugin package name to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export default Component;
 ## Usage
 
 ```
-$ npm install --save-dev "vue-template-compiler@2"
+$ npm install --save-dev esbuild-vue-plugin "vue-template-compiler@2"
 ```
 
 [Follow instructions](https://esbuild.github.io/plugins/#using-plugins) on using esbuild plugins.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "esbuild-vue-plugin",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Vue plugin for esbuild",
 	"repository": "github:few-far/esbuild-vue-plugin",
 	"main": "main.js",


### PR DESCRIPTION
After the changes to prevent the implicit strict mode, the code was updated but the package version remained the same, so the `npm` package is still on version `0.2.0`